### PR TITLE
fix(git): typo in configuration

### DIFF
--- a/home/git.nix
+++ b/home/git.nix
@@ -10,7 +10,7 @@
         filemode = false;
       };
       submodule = {
-        recruse = true;
+        recurse = true;
       };
       init = {
         defaultBranch = "master";


### PR DESCRIPTION
* doc states this should be called `submodule.recurse`